### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://uwaim.visualstudio.com/0fd24645-614f-4d43-8f8c-f3dc4bea42a2/2b6611a8-f7db-4efb-8d25-88c185c91a0f/_apis/work/boardbadge/0dae3323-29bd-47df-a970-f270f2b991cd)](https://uwaim.visualstudio.com/0fd24645-614f-4d43-8f8c-f3dc4bea42a2/_boards/board/t/2b6611a8-f7db-4efb-8d25-88c185c91a0f/Microsoft.RequirementCategory)
 # University Advancement Information Management
 
 This team is for repositories containing work product related to the [University Advancement](https://ua.uw.edu/) [Information Management](https://depts.washington.edu/uwadv/data-technology-resources/) department at the [University of Washington](https://uw.edu).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#549](https://uwaim.visualstudio.com/0fd24645-614f-4d43-8f8c-f3dc4bea42a2/_workitems/edit/549). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.